### PR TITLE
Fix package name to respect Composer rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Snapchat/business-sdk-php",
+    "name": "snapchat/business-sdk-php",
     "version": "1.0.1",
     "description": "PHP Business SDK for Snap Conversion API)",
     "keywords": [


### PR DESCRIPTION
## Issue

When trying to run `composer i` you get a validation message from Composer, instead of ignoring this, we can lowercase name.

![image](https://user-images.githubusercontent.com/1175548/234818865-31056be9-f681-441b-ac42-f57d6f7720ca.png)
