### PR TITLE
downgrade monolog package from ^2.8.0 to ^1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
-        "monolog/monolog": "^2.8.0"
+        "monolog/monolog": "^1.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
## Problem

We've had an issue on out project installing the Snapchat SDK and saw it requires a high version of Monolog package. I don't think it's necessary, and for widely used packages, we should opt for minimal requirements for the package to work for a variety of projects.

I tried to run some automated tests so that it is easier for the maintainer to validate, but I think the tests are broken