### PR TITLE
downgrade guzzle package from ^7.3 to ^6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^1.7 || ^2.0",
+        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/psr7": "^1.6 || ^2.0",
         "monolog/monolog": "^2.8.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Problem

We've had an issue on out project installing the Snapchat SDK and saw it requires a high version of Guzzle package. I don't think it's necessary, and for widely used packages, we should opt for minimal requirements for the package to work for a variety of projects.

I tried to run some automated tests so that it is easier for the maintainer to validate, but I think the tests are broken